### PR TITLE
Update circleDetection.gsql

### DIFF
--- a/demos/guru_scripts/loop_detection_demo/queries/circleDetection.gsql
+++ b/demos/guru_scripts/loop_detection_demo/queries/circleDetection.gsql
@@ -266,7 +266,9 @@ CREATE QUERY circleDetection (vertex<account> srcId, int stepLowLimit = 3, int s
             tgt.@edgeTupleList = tgt.@newEdgeTupleList,
             tgt.@receiveNewPath = true,
             tgt.@newEdgeTupleList.clear()
-        END
+        END,
+        //clean up to reduce memory footprint
+        src.@edgeTupleList.clear()
       HAVING tgt.@receiveNewPath == true
     ;
 
@@ -302,7 +304,9 @@ CREATE QUERY circleDetection (vertex<account> srcId, int stepLowLimit = 3, int s
             END,
             tgt.@receiveNewPath = true,
             tgt.@newEdgeTupleList.clear()
-        END
+        END,
+        //clean up to reduce memory footprint
+        src.@edgeTupleList.clear()
       HAVING tgt.@receiveNewPath == true and tgt != srcId
     ;
 


### PR DESCRIPTION
Cleaning up previously visited list accumulators greatly improves memory usage for this algorithm. This is done by removing the edgeTupleList from the source in the post-Accum step as the new paths are already forwarded to the next vertexes in the path. To my understanding, at that point, there is no need to store the paths in source vertex.

At a minimum please provide the following:

### Description of the Change

<!--

We must be able to understand the purpose of your change from this description.

-->

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->
